### PR TITLE
Bugfix: locate_protocol on Indicator protocol

### DIFF
--- a/boot_services/src/boot_services.rs
+++ b/boot_services/src/boot_services.rs
@@ -449,14 +449,14 @@ pub trait BootServices: Sized {
         &self,
         protocol: &P,
         registration: Option<Registration>,
-    ) -> Result<&'static mut I, efi::Status> {
+    ) -> Result<Option<&'static mut I>, efi::Status> {
         //SAFETY: The generic Protocol ensure that the interfaces is the right type for the specified protocol.
         unsafe {
             self.locate_protocol_unchecked(
                 protocol.protocol_guid(),
                 registration.map_or(ptr::null_mut(), |r| r.as_ptr()),
             )
-            .map(|ptr| (ptr as *mut I).as_mut().unwrap())
+            .map(|ptr| if ptr.is_null() { None } else { Some((ptr as *mut I).as_mut().unwrap()) })
         }
     }
 

--- a/boot_services/src/boot_services.rs
+++ b/boot_services/src/boot_services.rs
@@ -1496,19 +1496,20 @@ mod test {
         let boot_services = boot_services!(locate_protocol = efi_locate_protocol);
 
         extern "efiapi" fn efi_locate_protocol(
-            guid: *mut efi::Guid,
+            protocol_guid: *mut efi::Guid,
             registration: *mut c_void,
             interface: *mut *mut c_void,
         ) -> efi::Status {
             unsafe {
-                assert_eq!(
-                    guid.as_mut().unwrap(),
-                    &device_path::PROTOCOL_GUID,
-                    "Guid should have been Device Path guid"
-                );
+                assert!(!protocol_guid.is_null(), "Protocol guid should not be null");
                 assert!(registration.is_null(), "Registration should be a null pointer");
+                assert!(!interface.is_null(), "Interface should not be a null pointer");
+                assert_eq!(
+                    protocol_guid.as_mut().unwrap(),
+                    &device_path::PROTOCOL_GUID,
+                    "Protocol guid should have been Device Path guid"
+                );
                 let device_path_interface = interface as *mut *mut device_path::Protocol;
-                assert!(!device_path_interface.is_null(), "Interface should not be a null pointer");
 
                 *device_path_interface =
                     &DEVICE_PATH_PROTOCOL_INTERFACE as *const device_path::Protocol as *mut device_path::Protocol;
@@ -1527,20 +1528,21 @@ mod test {
         let boot_services = boot_services!(locate_protocol = efi_locate_protocol);
 
         extern "efiapi" fn efi_locate_protocol(
-            guid: *mut efi::Guid,
+            protocol_guid: *mut efi::Guid,
             registration: *mut c_void,
             interface: *mut *mut c_void,
         ) -> efi::Status {
             use r_efi::protocols::device_path;
             unsafe {
-                assert_eq!(
-                    guid.as_mut().unwrap(),
-                    &device_path::PROTOCOL_GUID,
-                    "Guid should have been Device Path guid"
-                );
+                assert!(!protocol_guid.is_null(), "Protocol guid should not be null");
                 assert!(registration.is_null(), "Registration should be a null pointer");
+                assert!(!interface.is_null(), "Interface should not be a null pointer");
+                assert_eq!(
+                    protocol_guid.as_mut().unwrap(),
+                    &device_path::PROTOCOL_GUID,
+                    "Protocol guid should have been Device Path guid"
+                );
                 let device_path_interface = interface as *mut *mut device_path::Protocol;
-                assert!(!device_path_interface.is_null(), "Interface should not be a null pointer");
 
                 // set to null to simulate an indicator protocol
                 *device_path_interface = core::ptr::null_mut() as *mut device_path::Protocol;


### PR DESCRIPTION
## Description
Modified `locate_protocol` to return an `Option<&'static mut I>`. There are many protocols that are only indicators of events/feature availability.  These protocols are installed with null pointers; without this change, locate_protocol panics due to dereferencing the null protocol interface.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?: Now allows indicator protocols to be located using the `BootServices` struct
- [ ] Impacts security?
- [x] Breaking change? The return of `locate_protocol` now has an extra `Option` layer that will need to be handled.
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Added and ran tests for `locate_protocol`

## Integration Instructions
Update existing `locate_protocol` usage to handle `Option`
New non-Indicator protocol patterns:
```rust
let protocol_interface = boot_services.locate_protocol(&ADVANCED_LOGGER_PROTOCOL, None)?.ok_or(efi::Status::INCOMPATIBLE_VERSION)?;

let protcol_interface = match boot_services.locate_protocol(&ADVANCED_LOGGER_PROTOCOL, None) {
    Ok(Some(protcol_interface)) => protcol_interface,
    Ok(None) => {
        return efi::Status::INCOMPATIBLE_VERSION;
    }
    Err(status) => {
        return status;
    }
};
```

Indicator protocol patterns:
```rust
boot_services.locate_protocol(&VARIABLE_WRITE_ARCH_PROTOCOL_GUID, None)?;

match boot_services.locate_protocol(&VARIABLE_WRITE_ARCH_PROTOCOL_GUID, None) {
    Err(status) => Err(status)?,
    Ok(..) => { /* do stuff */ }

    // or more pedantic
    Ok(Some(inteface)) => Err(efi::Status::INCOMPATIBLE_VERSION)?,
    Ok(None) => { /* do stuff */ }
};


let located = boot_services.locate_protocol(&VARIABLE_WRITE_ARCH_PROTOCOL_GUID, None).is_ok_and(|option| option.is_none());

// or just
let located = boot_services.locate_protocol(&VARIABLE_WRITE_ARCH_PROTOCOL_GUID, None).is_ok();
```