### PR TITLE
macros: Add new module for helper macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 extern crate alloc;
 
+pub mod macros;
+
 #[cfg(feature = "boot_services")]
 pub use boot_services;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,24 @@
+//! General purpose utility macros.
+//!
+
+/// Yields a &'static str that is the name of the containing function.
+///
+/// # Example
+/// ```
+/// fn demo_fn() {
+///   use mu_rust_helpers::function;
+///
+///   std::println!("This function is called {}", function!());
+/// }
+/// ```
+#[macro_export]
+macro_rules! function {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            core::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        name.strip_suffix("::f").unwrap()
+    }};
+}


### PR DESCRIPTION
## Description

The first macro here is `function!()` which prints the name of the containing function. Originally implemented in the advanced logger crate and transferred here for broader accessibility.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- Cargo doc, tests, build, and usage in a consuming crate

## Integration Instructions

Use the `mu_rust_helpers::function` macro if it is useful for you.