### PR TITLE
guid: guid! macro ergonomics improvement

### DIFF
--- a/guid/src/guid.rs
+++ b/guid/src/guid.rs
@@ -1,14 +1,14 @@
 #![cfg_attr(target_os = "uefi", no_std)]
 
 use r_efi::efi;
-use uuid::uuid;
+pub use uuid::uuid;
 
 /// Macro for creating an `efi::Guid` from string representation.
 /// This is a wrapper for `uuid!` from the uuid crate.
 #[macro_export]
 macro_rules! guid {
     ($guid_str:expr) => {
-        efi::Guid::from_bytes(&uuid!($guid_str).to_bytes_le())
+        efi::Guid::from_bytes(&$crate::uuid!($guid_str).to_bytes_le())
     };
 }
 


### PR DESCRIPTION
## Description

With the current structure of the guid! macro, the `uuid` crate must be added to the dependencies of any crate that uses the macro and the macro itself must be in scope. This provides poor ergonomics for anyone using the macro and the error for not having the `uuid` crate in scope is not the most clear.

```
error: cannot find macro `uuid` in this scope
   --> my_component\src\component.rs:170:9
    |
170 |         mu_rust_helpers::guid::guid!("4297bd81-1d1d-49aa-b138-7b54e5807264")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `uuid` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `mu_rust_helpers::guid::guid` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This commit updates the usage of the uuid macro, so that the macro does not require the `uuid` macro to be in scope (or the uuid crate to be a dependency at all). This is done by specifying that the uuid macro comes from the interior crate (using $crate). This does, however, re-export the uuid! macro, as it must be public for it to be used in other crates.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified the macro can now be used without the need of having the `uuid` crate as a dependency, or the `uuid::uuid!` macro in scope in the file.

## Integration Instructions

Consumers can remove the `uuid` crate if not used for any other purposes.
