### PR TITLE
remove Sized from BootServices trait

### DIFF
--- a/boot_services/src/allocation.rs
+++ b/boot_services/src/allocation.rs
@@ -41,7 +41,7 @@ impl Into<u32> for MemoryType {
 }
 
 #[derive(Debug)]
-pub struct MemoryMap<'a, B: BootServices> {
+pub struct MemoryMap<'a, B: BootServices + ?Sized> {
     pub descriptors: BootServicesBox<'a, [efi::MemoryDescriptor], B>,
     pub map_key: usize,
     pub descriptor_version: u32,

--- a/boot_services/src/boot_services.rs
+++ b/boot_services/src/boot_services.rs
@@ -88,7 +88,7 @@ unsafe impl Send for StandardBootServices<'static> {}
 
 /// Functions that are available *before* a successful call to EFI_BOOT_SERVICES.ExitBootServices().
 #[cfg_attr(any(test, feature = "mockall"), automock)]
-pub trait BootServices: Sized {
+pub trait BootServices {
     /// Create an event.
     ///
     /// [UEFI Spec Documentation: 7.1.1. EFI_BOOT_SERVICES.CreateEvent()](https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-createevent)
@@ -278,7 +278,7 @@ pub trait BootServices: Sized {
     /// # Safety
     ///
     /// When calling this method, you have to make sure that if *interface* pointer is non-null, it is adhereing to
-    /// the structure associated with the protocol.  
+    /// the structure associated with the protocol.
     unsafe fn install_protocol_interface_unchecked(
         &self,
         handle: Option<efi::Handle>,
@@ -348,7 +348,7 @@ pub trait BootServices: Sized {
     ///
     /// # Safety
     /// When calling this method, you have to make sure that if *new_protocol_interface* pointer is non-null, it is adhereing to
-    /// the structure associated with the protocol.  
+    /// the structure associated with the protocol.
     unsafe fn reinstall_protocol_interface_unchecked(
         &self,
         handle: efi::Handle,
@@ -432,7 +432,7 @@ pub trait BootServices: Sized {
     ///
     /// # Safety
     ///
-    /// When calling this method, you have to make sure that if *agent_handle* pointer is non-null.  
+    /// When calling this method, you have to make sure that if *agent_handle* pointer is non-null.
     unsafe fn open_protocol_unchecked(
         &self,
         handle: efi::Handle,
@@ -467,7 +467,7 @@ pub trait BootServices: Sized {
     /// # Safety
     ///
     /// When calling this method, you have to make sure that *driver_image_handle*'s last entry is null per UEFI specification.
-    ///  
+    ///
     /// [UEFI Spec Documentation: 7.3.12. EFI_BOOT_SERVICES.ConnectController()](https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-connectcontroller)
     unsafe fn connect_controller(
         &self,

--- a/boot_services/src/boxed.rs
+++ b/boot_services/src/boxed.rs
@@ -8,7 +8,7 @@ use core::{
 use crate::{allocation::MemoryType, BootServices};
 
 #[derive(Debug)]
-pub struct BootServicesBox<'a, T: ?Sized, B: BootServices> {
+pub struct BootServicesBox<'a, T: ?Sized, B: BootServices + ?Sized> {
     ptr: *mut T,
     boot_services: &'a B,
 }
@@ -47,7 +47,7 @@ impl<'a, T, B: BootServices> BootServicesBox<'a, [T], B> {
     }
 }
 
-impl<T: ?Sized, B: BootServices> Drop for BootServicesBox<'_, T, B> {
+impl<T: ?Sized, B: BootServices + ?Sized> Drop for BootServicesBox<'_, T, B> {
     fn drop(&mut self) {
         let _ = self.boot_services.free_pool(self.ptr as *mut u8);
     }


### PR DESCRIPTION
## Description

Relax the trait bounds on various consumers of `BootServices` to allow `BootServices` to be unsized. This will permit usage of `BootServices` trait objects. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified that unit tests still pass.

## Integration Instructions

N/A
