### PR TITLE
Add workspace publishing [Rebase & FF]

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,39 @@
+# @file publish-release.yml
+#
+# A Github workflow that publishes all crates in a repository to crates.io and creates a release on
+# GitHub.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+name: Publish Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  validate_branch:
+    name: Validate Branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Validate Branch
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+              echo "This workflow can only be run on the main branch."
+              exit 1
+          fi
+
+  release:
+    name: Release
+    needs: validate_branch
+    uses: microsoft/mu_devops/.github/workflows/ReleaseWorkflow.yml@main
+    secrets:
+      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+    permissions:
+      contents: write
+      actions: read

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,14 @@ tpl_mutex = ["dep:mu_uefi_tpl_mutex"]
 uefi_decompress = ["dep:mu_uefi_decompress"]
 
 [dependencies]
-mu_uefi_boot_services = { path = "./boot_services", version = "2", optional = true }
-mu_uefi_decompress = { path = "./uefi_decompress", version = "2", optional = true }
-mu_uefi_guid = { path = "./guid", version = "2", optional = true }
+mu_uefi_boot_services = { workspace = true, optional = true }
+mu_uefi_decompress = { workspace = true, optional = true }
+mu_uefi_guid = { workspace = true, optional = true }
 mu_uefi_perf_timer = { path = "./perf_timer", version = "2", optional = true }
-mu_uefi_runtime_services = { path = "./runtime_services", version = "2", optional = true }
-mu_uefi_tpl_mutex = { path = "./tpl_mutex", version = "2", optional = true }
+mu_uefi_runtime_services = { workspace = true, optional = true }
+mu_uefi_tpl_mutex = { workspace = true, optional = true }
 
 [dev-dependencies]
-mu_uefi_boot_services = { path = "./boot_services", version = "2", features = ["mockall"]}
+mu_uefi_boot_services = { workspace = true, features = ["mockall"]}
 r-efi = { workspace = true }
-mu_uefi_runtime_services = { path = "./runtime_services", version = "2", features = ["mockall"]}
+mu_uefi_runtime_services = { workspace = true, features = ["mockall"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.1"
+version = "2.0.0"
 repository = "https://github.com/microsoft/mu_rust_helpers"
 license = "BSD-2-Clause-Patent"
 edition = "2021"
@@ -24,11 +24,11 @@ include = [
 
 [workspace.dependencies]
 log = "~0.4"
-mu_uefi_boot_services = { path="./boot_services" }
-mu_uefi_decompress = { path="./uefi_decompress" }
-mu_uefi_guid = { path="./guid" }
-mu_uefi_runtime_services = { path="./runtime_services" }
-mu_uefi_tpl_mutex = { path="./tpl_mutex" }
+mu_uefi_boot_services = { path="./boot_services", version = "2" }
+mu_uefi_decompress = { path="./uefi_decompress", version = "2" }
+mu_uefi_guid = { path="./guid", version = "2" }
+mu_uefi_runtime_services = { path="./runtime_services", version = "2" }
+mu_uefi_tpl_mutex = { path="./tpl_mutex", version = "2" }
 r-efi = "5.1.0"
 uuid = { version = "1.10.0", default-features = false}
 
@@ -52,14 +52,14 @@ tpl_mutex = ["dep:mu_uefi_tpl_mutex"]
 uefi_decompress = ["dep:mu_uefi_decompress"]
 
 [dependencies]
-mu_uefi_boot_services = { path = "./boot_services", version = "1", optional = true }
-mu_uefi_decompress = { path = "./uefi_decompress", version = "1", optional = true }
-mu_uefi_guid = { path = "./guid", version = "1", optional = true }
-mu_uefi_perf_timer = { path = "./perf_timer", version = "1", optional = true }
-mu_uefi_runtime_services = { path = "./runtime_services", version = "1", optional = true }
-mu_uefi_tpl_mutex = { path = "./tpl_mutex", version = "1", optional = true }
+mu_uefi_boot_services = { path = "./boot_services", version = "2", optional = true }
+mu_uefi_decompress = { path = "./uefi_decompress", version = "2", optional = true }
+mu_uefi_guid = { path = "./guid", version = "2", optional = true }
+mu_uefi_perf_timer = { path = "./perf_timer", version = "2", optional = true }
+mu_uefi_runtime_services = { path = "./runtime_services", version = "2", optional = true }
+mu_uefi_tpl_mutex = { path = "./tpl_mutex", version = "2", optional = true }
 
 [dev-dependencies]
-mu_uefi_boot_services = { path = "./boot_services", features = ["mockall"]}
+mu_uefi_boot_services = { path = "./boot_services", version = "2", features = ["mockall"]}
 r-efi = { workspace = true }
-mu_uefi_runtime_services = { path = "./runtime_services", features = ["mockall"]}
+mu_uefi_runtime_services = { path = "./runtime_services", version = "2", features = ["mockall"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,14 @@ resolver = "2"
 members = [
     "boot_services",
     "guid",
+    "perf_timer",
     "runtime_services",
     "tpl_mutex",
     "uefi_decompress",
-    "perf_timer",
 ]
 
 [workspace.package]
+version = "1.2.1"
 repository = "https://github.com/microsoft/mu_rust_helpers"
 license = "BSD-2-Clause-Patent"
 edition = "2021"
@@ -17,48 +18,48 @@ include = [
   "Cargo.toml",
   "LICENSE*",
   "README.md",
-  "examples/**/*"
+  "examples/**/*",
+  "src/**",
 ]
 
 [workspace.dependencies]
-r-efi = "5.1.0"
-boot_services = { path="./boot_services" }
-runtime_services = { path="./runtime_services" }
-guid = { path="./guid" }
-tpl_mutex = { path="./tpl_mutex" }
-uefi_decompress = { path="./uefi_decompress" }
-uuid = { version = "1.10.0", default-features = false}
 log = "~0.4"
+mu_uefi_boot_services = { path="./boot_services" }
+mu_uefi_decompress = { path="./uefi_decompress" }
+mu_uefi_guid = { path="./guid" }
+mu_uefi_runtime_services = { path="./runtime_services" }
+mu_uefi_tpl_mutex = { path="./tpl_mutex" }
+r-efi = "5.1.0"
+uuid = { version = "1.10.0", default-features = false}
 
 [package]
 name = "mu_rust_helpers"
-version = "1.2.0"
-description = ""
+description = "Helper functions for UEFI Rust applications"
+readme = "README.md"
+version.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
 include.workspace = true
 
 [features]
+boot_services = ["dep:mu_uefi_boot_services"]
 default = ["boot_services", "runtime_services", "guid", "tpl_mutex", "uefi_decompress", "perf_timer"]
-boot_services = ["dep:boot_services"]
-runtime_services = ["dep:runtime_services"]
-guid = ["dep:guid"]
-tpl_mutex = ["dep:tpl_mutex"]
-uefi_decompress = ["dep:uefi_decompress"]
-perf_timer = ["dep:perf_timer"]
+guid = ["dep:mu_uefi_guid"]
+perf_timer = ["dep:mu_uefi_perf_timer"]
+runtime_services = ["dep:mu_uefi_runtime_services"]
+tpl_mutex = ["dep:mu_uefi_tpl_mutex"]
+uefi_decompress = ["dep:mu_uefi_decompress"]
 
 [dependencies]
-boot_services = { path = "./boot_services", version = "1.0.0", optional = true }
-guid = { path = "./guid", version = "0.1.0", optional = true }
-runtime_services = { path = "./runtime_services", version = "0.1.0", optional = true }
-tpl_mutex = { path = "./tpl_mutex", version = "0.1.0", optional = true }
-uefi_decompress = { path = "./uefi_decompress", version = "0.1.0", optional = true }
-perf_timer = { path = "./perf_timer", version = "0.1.0", optional = true }
+mu_uefi_boot_services = { path = "./boot_services", version = "1", optional = true }
+mu_uefi_decompress = { path = "./uefi_decompress", version = "1", optional = true }
+mu_uefi_guid = { path = "./guid", version = "1", optional = true }
+mu_uefi_perf_timer = { path = "./perf_timer", version = "1", optional = true }
+mu_uefi_runtime_services = { path = "./runtime_services", version = "1", optional = true }
+mu_uefi_tpl_mutex = { path = "./tpl_mutex", version = "1", optional = true }
 
 [dev-dependencies]
+mu_uefi_boot_services = { path = "./boot_services", features = ["mockall"]}
 r-efi = { workspace = true }
-boot_services = { path = "./boot_services", features = ["mockall"]}
-runtime_services = { path = "./runtime_services", features = ["mockall"]}
-
-
+mu_uefi_runtime_services = { path = "./runtime_services", features = ["mockall"]}

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ Most Project Mu Rust repos contain an individual feature. This repo contains cod
 for UEFI Rust code. The repo is composed of separate crates for different purposes. Therefore, the code maintained in
 this repo may overall be less cohesive than other repos.
 
+## Current State
+
+This repository is in the early stages of development. The crate is not complete and should not be used in production
+at this time. Major changes to the API may occur. We are interested in feedback and contributions and we want the
+flexibility to make changes as needed.
+
 ## Requirements
 
-- rustc >= 1.68.0
+![rustc Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fmu_rust_helpers%2Frefs%2Fheads%2Fmain%2Frust-toolchain.toml&query=%24.toolchain.channel&style=for-the-badge&logo=rust&logoColor=FFC832&label=rustc%20version&color=0B7261)
 
 ## Build
 

--- a/boot_services/Cargo.toml
+++ b/boot_services/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
-name = "boot_services"
-version = "1.0.0"
-edition = "2021"
+name = "mu_uefi_boot_services"
+resolver = "2"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Rust-friendly UEFI Boot Service wrappers."
 
 [lib]
+name = "boot_services"
 path = "src/boot_services.rs"
 
 [features]

--- a/boot_services/Cargo.toml
+++ b/boot_services/Cargo.toml
@@ -18,7 +18,7 @@ mockall = ["dep:mockall"]
 
 [dependencies]
 r-efi = { workspace = true }
-mockall = { version = "*", optional = true }
+mockall = { version = "0.13", optional = true }
 
 [dev-dependencies]
 mockall = { version = "0.13.0" }

--- a/guid/Cargo.toml
+++ b/guid/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
-name = "guid"
-version = "0.1.0"
-edition = "2021"
+name = "mu_uefi_guid"
+resolver = "2"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "UEFI GUID support."
 
 [lib]
+name = "guid"
 path = "src/guid.rs"
 
 [dependencies]

--- a/perf_timer/Cargo.toml
+++ b/perf_timer/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
+name = "mu_uefi_perf_timer"
+resolver = "2"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Performance timer support."
+
+[lib]
 name = "perf_timer"
-version = "0.1.0"
-edition = "2021"
 
 [features]
 default = []

--- a/runtime_services/Cargo.toml
+++ b/runtime_services/Cargo.toml
@@ -18,7 +18,7 @@ mockall = ["dep:mockall"]
 
 [dependencies]
 r-efi = { workspace = true }
-mockall = { version = "*", optional = true }
+mockall = { version = "0.13", optional = true }
 fallible-streaming-iterator = { version = "0.1.9" }
 
 [dev-dependencies]

--- a/runtime_services/Cargo.toml
+++ b/runtime_services/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
-name = "runtime_services"
-version = "0.1.0"
-edition = "2021"
+name = "mu_uefi_runtime_services"
+resolver = "2"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Rust-friendly UEFI Runtime Service wrappers."
 
 [lib]
+name = "runtime_services"
 path = "src/runtime_services.rs"
 
 [features]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,7 @@
 [toolchain]
 channel = "1.80.0"
 
-[tool]
+[tools]
 cargo-make = "0.37.9"
 cargo-tarpaulin = "0.31.2"
+cargo-release = "0.25.12"

--- a/tpl_mutex/Cargo.toml
+++ b/tpl_mutex/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
-name = "tpl_mutex"
-version = "0.1.0"
-edition = "2021"
+name = "mu_uefi_tpl_mutex"
 resolver = "2"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Task Priority Level (TPL) mutual exclusion support."
 
 [lib]
+name = "tpl_mutex"
 path = "src/tpl_mutex.rs"
 
 [dependencies]
 r-efi = { workspace=true }
-boot_services = { workspace=true }
+mu_uefi_boot_services = { workspace=true }
 
 [dev-dependencies]
 mockall = { version = "0.13.0" }
-boot_services = { workspace=true, features = ["mockall"]}
+mu_uefi_boot_services = { workspace=true, features = ["mockall"]}

--- a/uefi_decompress/Cargo.toml
+++ b/uefi_decompress/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
-name = "uefi_decompress"
-version = "0.1.0"
-edition = "2021"
+name = "mu_uefi_decompress"
+resolver = "2"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "UEFI decompression."
 
 [lib]
 name = "uefi_decompress"


### PR DESCRIPTION
## Description

Changes to support publishing crates from this repo.

---

**Add crate publishing support**

- Crates are currently being published from Mu repositories. The
  expectation is that the code will be moved to another repo after a
  period of time outside of Project Mu. To differentiate these early
  versions of the crates, the package names are prefixed with
  "mu_uefi".
- Keep library names consistent with current code.
- Add additional info to crates common to the workspace.
- Add GitHub publishing workflow to the repo.
- Add readme to Cargo.toml.
- Sort some sections in the workspace Cargo.toml for ease of reading
  information.

---

**Update version to 2.0.0**

Version update for the upcoming release.

---

**Cargo.toml: Consolidate workspace dependency versions**

Use the workspace.dependencies versions to reduce maintenance
overhead.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Dry run of release to crates.io
- Publish of crates to a test registry
- GitHub workflow test on fork

## Integration Instructions

- Use the published crates after this change is merged and the crates are published. Use the new crate names when updating.