### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Repo File Sync: .sync/rust_config/rustfmt.toml: Use Rust default of 4 space indentation
+386826ccec52fbf33f7e238ef735fbace3774016


### PR DESCRIPTION
## Description

This file should only be used to ignore changes that are completely non-functional.

In this case, it is ignoring the commit that updated from 2 to 4 spaces.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`> git blame --ignore-revs-file .git-blame-ignore-revs boot_services/src/boot_services.rs`

## Integration Instructions

Set up your git config to you the ignore file if it is not already globally set to use files with the `.git-blame-ignore-revs` naming convention.