### PR TITLE
Comprehensive timer fix for QEMU

### DIFF
--- a/perf_timer/Cargo.toml
+++ b/perf_timer/Cargo.toml
@@ -16,3 +16,6 @@ validate_cpu_features = []
 
 [target.'cfg(target_arch="aarch64")'.dependencies]
 aarch64-cpu = { version = "10.0.0", optional = false }
+
+[dependencies]
+log = "~0.4"

--- a/perf_timer/src/arch.rs
+++ b/perf_timer/src/arch.rs
@@ -7,7 +7,7 @@ pub use x64::X64 as Arch;
 pub use aarch64::Aarch64 as Arch;
 
 // QEMU uses the ACPI frequency when CPUID-based frequency determination is not available.
-const QEMU_DEFAULT_FREQUENCY: u64 = 3579545;
+const DEFAULT_ACPI_TIMER_FREQUENCY: u64 = 3579545;
 
 static CPU_FREQUENCY: AtomicU64 = AtomicU64::new(0);
 
@@ -73,7 +73,7 @@ pub(crate) mod x64 {
                 // Use leaf 0x15
                 let frequency = (ecx as u64 * ebx as u64) / eax as u64;
                 CPU_FREQUENCY.store(frequency, Ordering::Relaxed);
-                log::info!("Used CPUID leaf 0x15 to determine CPU frequency: {}", frequency);
+                log::trace!("Used CPUID leaf 0x15 to determine CPU frequency: {}", frequency);
                 return frequency;
             }
 
@@ -82,14 +82,14 @@ pub(crate) mod x64 {
                 // Use leaf 0x16, which gives the frequency in MHz.
                 let frequency = (eax * 1_000_000) as u64;
                 CPU_FREQUENCY.store(frequency, Ordering::Relaxed);
-                log::info!("Used CPUID leaf 0x16 to determine CPU frequency: {}", frequency);
+                log::trace!("Used CPUID leaf 0x16 to determine CPU frequency: {}", frequency);
                 return frequency;
             }
 
             log::warn!("Unable to determine CPU frequency using CPUID leaves, using default ACPI timer frequency");
 
-            CPU_FREQUENCY.store(QEMU_DEFAULT_FREQUENCY, Ordering::Relaxed);
-            QEMU_DEFAULT_FREQUENCY
+            CPU_FREQUENCY.store(DEFAULT_ACPI_TIMER_FREQUENCY, Ordering::Relaxed);
+            DEFAULT_ACPI_TIMER_FREQUENCY
         }
     }
 }

--- a/perf_timer/src/lib.rs
+++ b/perf_timer/src/lib.rs
@@ -31,12 +31,12 @@ impl Instant {
 
     /// Create a new instant from a cpu count.
     pub fn from_cpu_count(cpu_count: u64) -> Self {
-        Self { cpu_count, frequency: Arch::cpu_count_frequency() }
+        Self { cpu_count, frequency: Arch::perf_frequency() }
     }
 
     /// Create a new instant from the start of the counter.
     pub fn beginning() -> Self {
-        Self { cpu_count: Arch::cpu_count_start(), frequency: Arch::cpu_count_frequency() }
+        Self { cpu_count: Arch::cpu_count_start(), frequency: Arch::perf_frequency() }
     }
 
     /// Return the amount of time from `earlier` adn this instant.


### PR DESCRIPTION
## Description

Fix divide by zero error in timer for QEMU and improve frequency calculation overall. The new approach attempts to use CPUID leaf 0x16 (for nominal frequency on QEMU), as well as CPUID leaf 0x15 (for TSC frequency on physical platforms), and defaults to the ACPI frequency if both CPUID leaves fail (same behavior as mu_basecore).

I also added an ability to cache the frequency value since it should not change during runtime for more consistent perf results.

Leaving as draft for now because I'm unsure if this is the best strategy for timing.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
I tested all 3 cases (Skylake QEMU, physical platform, qemu64) and all give reasonable results without crashing.

## Integration Instructions
N/A. Although it should be noted for perf, we would generally prefer using a realistic cpu model or a physical platform over `qemu64`.
