### PR TITLE
Fix build error on aarm64.

### DIFF
--- a/perf_timer/src/arch.rs
+++ b/perf_timer/src/arch.rs
@@ -108,7 +108,7 @@ pub(crate) mod aarch64 {
             registers::CNTPCT_EL0.get()
         }
 
-        fn cpu_count_frequency() -> u64 {
+        fn perf_frequency() -> u64 {
             registers::CNTFRQ_EL0.get()
         }
     }


### PR DESCRIPTION
## Description

There was an error when building on aarm64. A function name has changed but not for arm, so it didn't build.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Building the repo.

## Integration Instructions

N/A
