### PR TITLE
guid: Expand no_std to all non-test configs

### DIFF
--- a/guid/src/guid.rs
+++ b/guid/src/guid.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_os = "uefi", no_std)]
+#![cfg_attr(not(test), no_std)]
 
 use r_efi::efi;
 pub use uuid::uuid;


### PR DESCRIPTION
## Description

When building this crate with a non-uefi target, the crate lacks a no-std attribute, failing the build if the target doesn't have std (e.g with a freestanding target).

## How This Was Tested

```cargo check --target x86_64-unknown-none```

## Integration Instructions

N/A