### PR TITLE
Bump r-efi to v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 log = "~0.4"
 mu_uefi_decompress = { path="./uefi_decompress", version = "4" }
 mu_uefi_guid = { path="./guid", version = "4" }
-r-efi = "6"
+r-efi = "7"
 uuid = { version = "1.10.0", default-features = false}
 
 [package]


### PR DESCRIPTION
## Description

Bumps the workspace `r-efi` pin from v6 to v7.

The single breaking change in r-efi v7 (`MemoryAttributesTable.reserved` renamed to `flags`) is not exercised by any crate in this workspace, so the bump is source-compatible — no code changes required.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo check --workspace`, `cargo test --workspace`, and `cargo clippy --workspace --all-targets` all pass.

## Integration Instructions

N/A.
