### PR TITLE
Upgrade to r-efi v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.0.0"
+version = "4.1.0"
 repository = "https://github.com/microsoft/mu_rust_helpers"
 license = "BSD-2-Clause-Patent"
 edition = "2021"
@@ -23,7 +23,7 @@ include = [
 log = "~0.4"
 mu_uefi_decompress = { path="./uefi_decompress", version = "4" }
 mu_uefi_guid = { path="./guid", version = "4" }
-r-efi = "6"
+r-efi = "7"
 uuid = { version = "1.10.0", default-features = false}
 
 [package]

--- a/uefi_decompress/src/lib.rs
+++ b/uefi_decompress/src/lib.rs
@@ -768,11 +768,21 @@ mod test {
         compressed_buffer[0] = 0x08;
 
         let mut uefi_uncompressed = Vec::new();
-        assert!(decompress_into_with_algo(&compressed_buffer, &mut uefi_uncompressed, crate::DecompressionAlgorithm::UefiDecompress).is_ok());
+        assert!(decompress_into_with_algo(
+            &compressed_buffer,
+            &mut uefi_uncompressed,
+            crate::DecompressionAlgorithm::UefiDecompress
+        )
+        .is_ok());
         assert_eq!(uefi_uncompressed.len(), 0);
 
         let mut tiano_uncompressed = Vec::new();
-        assert!(decompress_into_with_algo(&compressed_buffer, &mut tiano_uncompressed, crate::DecompressionAlgorithm::TianoDecompress).is_ok());
+        assert!(decompress_into_with_algo(
+            &compressed_buffer,
+            &mut tiano_uncompressed,
+            crate::DecompressionAlgorithm::TianoDecompress
+        )
+        .is_ok());
         assert_eq!(tiano_uncompressed.len(), 0);
     }
 


### PR DESCRIPTION
## Description

Patina is moving to r-efi v7, so upgrade mu_rust_helpers.

This also updates formatting in a test that cargo fmt generated.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with greater Patina changes.

## Integration Instructions

As Patina moves to r-efi v7, so should platforms to contain only a single copy of the crate.
