### PR TITLE
Mark crates as deprecated and bump version to 5.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.1.0"
+version = "5.0.0"
 repository = "https://github.com/microsoft/mu_rust_helpers"
 license = "BSD-2-Clause-Patent"
 edition = "2021"
@@ -21,14 +21,14 @@ include = [
 
 [workspace.dependencies]
 log = "~0.4"
-mu_uefi_decompress = { path="./uefi_decompress", version = "4" }
-mu_uefi_guid = { path="./guid", version = "4" }
+mu_uefi_decompress = { path="./uefi_decompress", version = "5" }
+mu_uefi_guid = { path="./guid", version = "5" }
 r-efi = "7"
 uuid = { version = "1.10.0", default-features = false}
 
 [package]
 name = "mu_rust_helpers"
-description = "Helper functions for UEFI Rust applications"
+description = "DEPRECATED: Please use the patina crate instead. Helper functions for UEFI Rust applications."
 readme = "README.md"
 version.workspace = true
 repository.workspace = true
@@ -45,7 +45,7 @@ uefi_decompress = ["dep:mu_uefi_decompress"]
 [dependencies]
 mu_uefi_decompress = { workspace = true, optional = true }
 mu_uefi_guid = { workspace = true, optional = true }
-mu_uefi_perf_timer = { path = "./perf_timer", version = "4", optional = true }
+mu_uefi_perf_timer = { path = "./perf_timer", version = "5", optional = true }
 
 [dev-dependencies]
 r-efi = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Mu Rust Helpers
 
+> **DEPRECATED**: This repository has been deprecated. Most functionality has moved to the [patina](https://crates.io/crates/patina)
+> crate.
+
 [Project Mu](https://microsoft.github.io/mu) Rust UEFI helper code.
 
 Most Project Mu Rust repos contain an individual feature. This repo contains code that provides helper functionality

--- a/guid/Cargo.toml
+++ b/guid/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-description = "UEFI GUID support."
+description = "DEPRECATED: Please use the patina crate instead. UEFI GUID support."
 
 [lib]
 name = "guid"

--- a/guid/src/guid.rs
+++ b/guid/src/guid.rs
@@ -1,3 +1,4 @@
+#![deprecated(since = "5.0.0", note = "This crate has been deprecated; please use the patina crate instead.")]
 #![cfg_attr(target_os = "uefi", no_std)]
 
 use r_efi::efi;

--- a/perf_timer/Cargo.toml
+++ b/perf_timer/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-description = "Performance timer support."
+description = "DEPRECATED: No longer maintained. Performance timer support."
 
 [lib]
 name = "perf_timer"

--- a/perf_timer/src/lib.rs
+++ b/perf_timer/src/lib.rs
@@ -1,3 +1,4 @@
+#![deprecated(since = "5.0.0", note = "This crate is deprecated and no longer updated.")]
 #![cfg_attr(not(test), no_std)]
 
 mod arch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deprecated(since = "5.0.0", note = "This crate has been deprecated; please use the patina crate instead.")]
+#![allow(deprecated)]
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;

--- a/uefi_decompress/Cargo.toml
+++ b/uefi_decompress/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-description = "UEFI decompression."
+description = "DEPRECATED: Please use the patina crate instead. UEFI decompression."
 
 [lib]
 name = "uefi_decompress"

--- a/uefi_decompress/src/lib.rs
+++ b/uefi_decompress/src/lib.rs
@@ -1,3 +1,4 @@
+#![deprecated(since = "5.0.0", note = "This crate has been deprecated; please use the patina crate instead.")]
 #![no_std]
 use bitvec::{field::BitField, order::Msb0, slice::BitSlice, view::BitView};
 


### PR DESCRIPTION
## Description

Bumps the major version to indicate that workspace crates are no longer maintained. Applies the deprecated attribute to each crate so a warning is shown when the crate is used.

https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute

It is applied to the module, so all child items inherit the attribute.

Readmes are updated as well. After this version is released, the GitHub repo will be archived.

The `allow(deprecated)` attribute is applied in lib.rs to allow `cargo make clippy` to work in this repo.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- Do not use this crate any longer. In most cases equivalent functionality is available in the [patina](https://crates.io/crates/patina) crate.